### PR TITLE
Fixed Formatting Errors

### DIFF
--- a/posts/en_EN/static/2015-08-11-faq.md
+++ b/posts/en_EN/static/2015-08-11-faq.md
@@ -70,7 +70,7 @@ The relative theory of money is a book published by Stephane Laborde which expla
 
 The amount is currency specific. But a general rule is defined in Duniter protocol:
 
-$latex UD_{t+1} = \max{(UD_t ; c \frac{M_t}{N_{t+1}} )}$
+![](http://latex.codecogs.com/gif.latex?%5Cinline%20UD_%7Bt&plus;1%7D%20%3D%20%5Cmax%7B%28UD_t%20%3B%20c%20%5Cfrac%7BM_t%7D%7BN_%7Bt&plus;1%7D%7D%20%29%7D)
 
 The value of the parameters _c_, _UD(0)_ and _dt_ are to be chosen by the implementation of a currency. For example, it could be:
 
@@ -78,7 +78,7 @@ The value of the parameters _c_, _UD(0)_ and _dt_ are to be chosen by the implem
 
 to lead to a 9.22% annual « c », but issued through 2 weeks chunks.
 
-<div class="ui info message">Note: 9.22% annual « c » is a central symmetry between generations of 80 years life expectancy members. Those results may be found in the [RMT](http://wiki.creationmonetaire.info/images/f/f8/TRM_2_718_b.pdf).</div>
+Note: 9.22% annual « c » is a central symmetry between generations of 80 years life expectancy members. Those results may be found in the [RMT](http://wiki.creationmonetaire.info/images/f/f8/TRM_2_718_b.pdf).
 
 ### How to know if I received UD?
 


### PR DESCRIPTION
An HTML div element was interfering with the rendering of a portion of the Markdown. Also, the Latex code is now an image.

**Note**: I do not know if it is better to save the image to the server or just fetch it from the third-party each time the page is loaded. I would prefer the latter for the purposes of reliability and good-will just in case the CodeCog servers can't handle too much traffic.
